### PR TITLE
Fix issue#4 with grid files larger than 2G

### DIFF
--- a/ocean_grid_generator.py
+++ b/ocean_grid_generator.py
@@ -298,7 +298,7 @@ def generate_grid_metrics(x,y,axis_units='degrees',Re=_default_Re, latlon_areafi
     return dx,dy,area,angle_dx
 
 
-def write_nc(x,y,dx,dy,area,angle_dx,axis_units='degrees',fnam=None,format='NETCDF3_CLASSIC',description=None,history=None,source=None,no_changing_meta=None):
+def write_nc(x,y,dx,dy,area,angle_dx,axis_units='degrees',fnam=None,format='NETCDF3_64BIT',description=None,history=None,source=None,no_changing_meta=None):
     import netCDF4 as nc
 
     if fnam is None:


### PR DESCRIPTION
- As reported in Issue #4 for resolutions finer than 1/12 degree the resulting grid file is larger than 2GB
  causing the tool to crash with:
  File "netCDF4/_netCDF4.pyx", line 4648, in netCDF4._netCDF4.Variable.__setitem__
  File "netCDF4/_netCDF4.pyx", line 4913, in netCDF4._netCDF4.Variable._put
  File "netCDF4/_netCDF4.pyx", line 1754, in netCDF4._netCDF4._ensure_nc_success
RuntimeError: NetCDF: Operation not allowed in define mode

- Changing format=NETCDF3_CLASSIC to NETCDF3_64BIT fixes this issue